### PR TITLE
Refactoring and Code clean

### DIFF
--- a/crates/regex-cli/Cargo.toml
+++ b/crates/regex-cli/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 clap = { version = "4.5.11", features = ["derive"] }
 regex-core = { path = "../regex-core" }
-thiserror = "1.0"
+thiserror = "2.0.18"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/regex-core/src/engine/ast.rs
+++ b/crates/regex-core/src/engine/ast.rs
@@ -1,5 +1,4 @@
 //! AST definitions for the regex engine.
-#![allow(dead_code)]
 
 /// Inclusive character range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8,17 +7,6 @@ pub struct CharRange {
     pub start: char,
     /// Inclusive end character.
     pub end: char,
-}
-
-impl CharRange {
-    /// Creates a range when `start <= end`; otherwise returns `None`.
-    pub fn new(start: char, end: char) -> Option<Self> {
-        if start <= end {
-            Some(Self { start, end })
-        } else {
-            None
-        }
-    }
 }
 
 /// Character class.
@@ -41,6 +29,7 @@ impl CharClass {
 }
 
 /// Zero-width assertion kinds.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Predicate {
     /// Line start assertion (`^`).

--- a/crates/regex-core/src/engine/compiler.rs
+++ b/crates/regex-core/src/engine/compiler.rs
@@ -1,5 +1,4 @@
 //! Compile an AST into an instruction sequence (`Instruction`).
-#![allow(dead_code)]
 
 use thiserror::Error;
 

--- a/crates/regex-core/src/engine/evaluator.rs
+++ b/crates/regex-core/src/engine/evaluator.rs
@@ -1,5 +1,4 @@
 //! Evaluate an instruction sequence.
-#![allow(dead_code)]
 
 use std::collections::HashSet;
 

--- a/crates/regex-core/src/engine/instruction.rs
+++ b/crates/regex-core/src/engine/instruction.rs
@@ -1,5 +1,4 @@
 //! Instruction set used by the compiler and evaluator.
-#![allow(dead_code)]
 
 use std::fmt::{self, Display};
 

--- a/crates/regex-core/src/engine/parser.rs
+++ b/crates/regex-core/src/engine/parser.rs
@@ -1,7 +1,6 @@
 //! Recursive-descent parser for regex patterns.
 //!
 //! The parser converts a pattern string into an `Ast` used by the compiler.
-#![allow(dead_code)]
 
 use crate::engine::ast::{Ast, CharClass, CharRange, Predicate};
 use thiserror::Error;


### PR DESCRIPTION
This pull request primarily refactors the `regex-core` crate's parser and AST engine to improve code clarity and maintainability, while also updating a dependency. The most significant changes include refactoring the single-character class construction logic, renaming variables for clarity, and updating the `thiserror` dependency.

**Parser and AST Refactoring:**

* Moved the single-character class constructor from a free function (`single_char_class`) to a private parser method (`parse_single_char`), and refactored all relevant code paths to use this method for consistency and encapsulation. [[1]](diffhunk://#diff-cba1fdb0c154cb5c50e9f049fb616f22c4d920de73f64e548259d92976b36c6dL208-R207) [[2]](diffhunk://#diff-cba1fdb0c154cb5c50e9f049fb616f22c4d920de73f64e548259d92976b36c6dL290-R286) [[3]](diffhunk://#diff-cba1fdb0c154cb5c50e9f049fb616f22c4d920de73f64e548259d92976b36c6dL372-R390)
* Renamed function and variable names from `regex` to `pattern` in the parser to better reflect their purpose and improve code readability. [[1]](diffhunk://#diff-cba1fdb0c154cb5c50e9f049fb616f22c4d920de73f64e548259d92976b36c6dL56-R57) [[2]](diffhunk://#diff-cba1fdb0c154cb5c50e9f049fb616f22c4d920de73f64e548259d92976b36c6dL68-R69)

**Dependency Update:**

* Updated the `thiserror` dependency from version `1.0` to `2.0.18` in `regex-cli/Cargo.toml`.

**Code Cleanliness:**

* Removed unnecessary `#![allow(dead_code)]` directives from several engine modules, and moved the attribute to only where needed. [[1]](diffhunk://#diff-1f3357af672680e40fc834d088bdad23fe7f73da5b2c1a8fe6d84ddfac9edef9L2) [[2]](diffhunk://#diff-c525b70c95a098a6316db65ee02ac3321435be2520b2a0e3edac022bdc50deeaL2) [[3]](diffhunk://#diff-8054fa7c6b1a841e544cab8563fb9be4f51ec757948e165d0062281e87c0980eL2) [[4]](diffhunk://#diff-793f76a9f54b366e19b88bf2a35783124442b402464d7d7605c13d567897945eL2) [[5]](diffhunk://#diff-cba1fdb0c154cb5c50e9f049fb616f22c4d920de73f64e548259d92976b36c6dL4) [[6]](diffhunk://#diff-1f3357af672680e40fc834d088bdad23fe7f73da5b2c1a8fe6d84ddfac9edef9R32)
* Removed the unused `CharRange::new` constructor, as it is no longer needed after the refactor.