### PR TITLE
feat: improve prefilter

### DIFF
--- a/.github/instructions/review/pr-review.instructions.md
+++ b/.github/instructions/review/pr-review.instructions.md
@@ -1,0 +1,24 @@
+# GitHub Copilot Instructions
+
+You are a senior code reviewer ensuring high standards of code quality
+
+When performing a code review, **respond in Japanese**.
+Please focus on the following checklist:
+
+## Checklist
+
+- Code is simple and readable
+- Functions and variables are well-named
+- No duplicated code
+- Proper error handling
+- No exposed secrets or API keys
+- Input validation implemented
+- Good test coverage
+- Performance considerations addressed
+- Time complexity of algorithms analyzed
+- Licenses of integrated libraries checked
+- Large functions (>50 lines)
+- Large files (>800 lines)
+- Deep nesting (>4 levels)
+- Hardcoded configuration values
+- Magic numbers without explanation

--- a/.github/instructions/review/pr-review.instructions.md
+++ b/.github/instructions/review/pr-review.instructions.md
@@ -16,7 +16,7 @@ Please focus on the following checklist:
 - Good test coverage
 - Performance considerations addressed
 - Time complexity of algorithms analyzed
-- Licenses of integrated libraries checked
+- Integrated libraries have compatible licenses (no license conflicts in dependencies)
 - No overly large functions (>50 lines)
 - No overly large files (>800 lines)
 - No deeply nested logic (>4 levels)

--- a/.github/instructions/review/pr-review.instructions.md
+++ b/.github/instructions/review/pr-review.instructions.md
@@ -17,8 +17,8 @@ Please focus on the following checklist:
 - Performance considerations addressed
 - Time complexity of algorithms analyzed
 - Licenses of integrated libraries checked
-- Large functions (>50 lines)
-- Large files (>800 lines)
-- Deep nesting (>4 levels)
-- Hardcoded configuration values
-- Magic numbers without explanation
+- No overly large functions (>50 lines)
+- No overly large files (>800 lines)
+- No deeply nested logic (>4 levels)
+- No hardcoded configuration values; configuration is externalized
+- No unexplained magic numbers; constants are named and documented

--- a/crates/regex-core/src/engine.rs
+++ b/crates/regex-core/src/engine.rs
@@ -13,6 +13,7 @@ use crate::engine::{
     parser::parse,
 };
 
+pub(crate) use ast::{Ast, extract_must_literals};
 pub use compiler::CompileError;
 pub use evaluator::EvalError;
 pub use instruction::Instruction;
@@ -62,7 +63,8 @@ where
 
 /// Parse and compile a pattern.
 pub fn compile_pattern(pattern: &str) -> Result<Vec<Instruction>, RegexError> {
-    let ast = parse(pattern)?;
+    let ast: Ast = parse(pattern)?;
+    let _must_literals = extract_must_literals(&ast);
     let instructions = compile(&ast)?;
     Ok(instructions)
 }

--- a/crates/regex-core/src/engine.rs
+++ b/crates/regex-core/src/engine.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::engine::{compiler::compile, evaluator::eval, parser::parse};
 
-pub(crate) use ast::{Ast, extract_must_literals};
+pub(crate) use ast::{Ast, analyze_ast};
 pub use compiler::CompileError;
 pub use evaluator::EvalError;
 pub use instruction::Instruction;
@@ -62,9 +62,9 @@ pub(crate) fn compile_pattern_with_must_literals(
     pattern: &str,
 ) -> Result<(Vec<Instruction>, Vec<String>), RegexError> {
     let ast: Ast = parse(pattern)?;
-    let must_literals = extract_must_literals(&ast);
+    let analysis = analyze_ast(&ast);
     let instructions = compile(&ast)?;
-    Ok((instructions, must_literals))
+    Ok((instructions, analysis.must_literals))
 }
 
 /// Match an instruction sequence against a line.

--- a/crates/regex-core/src/engine/ast.rs
+++ b/crates/regex-core/src/engine/ast.rs
@@ -1,5 +1,10 @@
 //! AST definitions for the regex engine.
 
+use std::{cmp::Ordering, collections::BTreeSet};
+
+/// Maximum number of must literals to retain.
+pub(crate) const MUST_LITERAL_LIMIT: usize = 16;
+
 /// Inclusive character range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CharRange {
@@ -110,4 +115,191 @@ pub enum Ast {
     Alternate(Box<Ast>, Box<Ast>),
     /// Backreference node (`\1`, `\2`, ...).
     Backreference(usize),
+}
+
+/// Extracts conservative must substrings from an AST.
+///
+/// Each returned string is guaranteed to appear in every successful match.
+/// The result is trimmed to at most `MUST_LITERAL_LIMIT` entries by:
+/// 1. longer byte length first
+/// 2. lexicographic byte order for equal lengths
+pub(crate) fn extract_must_literals(ast: &Ast) -> Vec<String> {
+    let mut must = extract_must_literal_set(ast);
+    prune_must_literal_set(&mut must);
+    must_literal_set_to_vec(must)
+}
+
+fn extract_must_literal_set(ast: &Ast) -> BTreeSet<String> {
+    match ast {
+        Ast::Empty | Ast::Assertion(_) | Ast::Backreference(_) => BTreeSet::new(),
+        Ast::CharClass(class) => {
+            let mut must = BTreeSet::new();
+            if let Some(literal) = class_single_literal(class) {
+                must.insert(literal.to_string());
+            }
+            must
+        }
+        Ast::Capture { expr, .. } => extract_must_literal_set(expr),
+        Ast::ZeroOrMore { .. } | Ast::ZeroOrOne { .. } => BTreeSet::new(),
+        Ast::OneOrMore { expr, .. } => extract_must_literal_set(expr),
+        Ast::Repeat { expr, min, .. } => {
+            if *min == 0 {
+                BTreeSet::new()
+            } else {
+                extract_must_literal_set(expr)
+            }
+        }
+        Ast::Concat(exprs) => extract_concat_must_literals(exprs),
+        Ast::Alternate(left, right) => {
+            let left_set = extract_must_literal_set(left);
+            let right_set = extract_must_literal_set(right);
+            intersect_must_literal_sets(left_set, right_set)
+        }
+    }
+}
+
+fn extract_concat_must_literals(exprs: &[Ast]) -> BTreeSet<String> {
+    let mut must = BTreeSet::new();
+    let mut literal_run = String::new();
+
+    for expr in exprs {
+        if let Some(literal) = ast_single_literal(expr) {
+            literal_run.push_str(&literal);
+            continue;
+        }
+
+        flush_literal_run(&mut must, &mut literal_run);
+        union_must_literal_sets(&mut must, extract_must_literal_set(expr));
+    }
+
+    flush_literal_run(&mut must, &mut literal_run);
+    prune_must_literal_set(&mut must);
+    must
+}
+
+fn ast_single_literal(ast: &Ast) -> Option<String> {
+    let Ast::CharClass(class) = ast else {
+        return None;
+    };
+    class_single_literal(class).map(|c| c.to_string())
+}
+
+fn class_single_literal(class: &CharClass) -> Option<char> {
+    if class.negated || class.ranges.len() != 1 {
+        return None;
+    }
+
+    let range = class.ranges.first()?;
+    if range.start == range.end {
+        Some(range.start)
+    } else {
+        None
+    }
+}
+
+fn flush_literal_run(set: &mut BTreeSet<String>, literal_run: &mut String) {
+    if literal_run.is_empty() {
+        return;
+    }
+
+    set.insert(std::mem::take(literal_run));
+    prune_must_literal_set(set);
+}
+
+fn union_must_literal_sets(dst: &mut BTreeSet<String>, src: BTreeSet<String>) {
+    dst.extend(src);
+    prune_must_literal_set(dst);
+}
+
+fn intersect_must_literal_sets(
+    left: BTreeSet<String>,
+    right: BTreeSet<String>,
+) -> BTreeSet<String> {
+    let mut intersection = BTreeSet::new();
+    for literal in left {
+        if right.contains(&literal) {
+            intersection.insert(literal);
+        }
+    }
+    prune_must_literal_set(&mut intersection);
+    intersection
+}
+
+fn prune_must_literal_set(set: &mut BTreeSet<String>) {
+    if set.len() <= MUST_LITERAL_LIMIT {
+        return;
+    }
+
+    let mut literals: Vec<String> = set.iter().cloned().collect();
+    literals.sort_by(|a, b| compare_literals(a, b));
+    literals.truncate(MUST_LITERAL_LIMIT);
+    *set = literals.into_iter().collect();
+}
+
+fn must_literal_set_to_vec(set: BTreeSet<String>) -> Vec<String> {
+    let mut literals: Vec<String> = set.into_iter().collect();
+    literals.sort_by(|a, b| compare_literals(a, b));
+    literals.truncate(MUST_LITERAL_LIMIT);
+    literals
+}
+
+fn compare_literals(a: &str, b: &str) -> Ordering {
+    b.len()
+        .cmp(&a.len())
+        .then_with(|| a.as_bytes().cmp(b.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MUST_LITERAL_LIMIT, extract_must_literals};
+    use crate::engine::parser::parse;
+
+    #[test]
+    fn test_extract_must_literals_dot_star_abc_dot_star() {
+        let ast = parse(".*abc.*").unwrap();
+        let actual = extract_must_literals(&ast);
+        assert_eq!(actual, vec!["abc".to_string()]);
+    }
+
+    #[test]
+    fn test_extract_must_literals_alternate_no_common_literal() {
+        let ast = parse("(abc|def)").unwrap();
+        let actual = extract_must_literals(&ast);
+        assert_eq!(actual, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_extract_must_literals_ab_star_c() {
+        let ast = parse("ab*c").unwrap();
+        let actual = extract_must_literals(&ast);
+        assert_eq!(actual, vec!["a".to_string(), "c".to_string()]);
+    }
+
+    #[test]
+    fn test_extract_must_literals_a_class_z() {
+        let ast = parse("a[a-z]z").unwrap();
+        let actual = extract_must_literals(&ast);
+        assert_eq!(actual, vec!["a".to_string(), "z".to_string()]);
+    }
+
+    #[test]
+    fn test_extract_must_literals_limit_prefers_longer_then_lexicographic() {
+        let pattern = [
+            "ppp", "aaa", "qqq", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj",
+            "kkk", "lll", "mmm", "nnn", "ooo", "zzzz",
+        ]
+        .join(".*");
+        let ast = parse(&pattern).unwrap();
+
+        let actual = extract_must_literals(&ast);
+        assert_eq!(actual.len(), MUST_LITERAL_LIMIT);
+        let expected = [
+            "zzzz", "aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii", "jjj", "kkk",
+            "lll", "mmm", "nnn", "ooo",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
+    }
 }

--- a/crates/regex-core/src/engine/evaluator.rs
+++ b/crates/regex-core/src/engine/evaluator.rs
@@ -251,15 +251,6 @@ fn eval_from_start_inner(
     Ok(false)
 }
 
-/// Evaluates whether `input` matches from the first character.
-pub fn eval_from_start(inst: &[Instruction], input: &str) -> Result<bool, EvalError> {
-    let chars: Vec<char> = input.chars().collect();
-    let capture_slots = max_capture_index(inst)
-        .checked_add(1)
-        .ok_or(EvalError::PCOverFlow)?;
-    eval_from_start_inner(inst, &chars, 0, capture_slots)
-}
-
 /// Evaluates whether `input` matches at any starting position.
 pub fn eval(inst: &[Instruction], input: &str) -> Result<bool, EvalError> {
     let chars: Vec<char> = input.chars().collect();
@@ -281,7 +272,7 @@ mod tests {
     use crate::engine::{
         ast::{CharClass, CharRange, Predicate},
         compiler::compile,
-        evaluator::{EvalError, eval, eval_from_start},
+        evaluator::{EvalError, eval},
         instruction::Instruction,
         parser::parse,
     };
@@ -349,13 +340,5 @@ mod tests {
         let inst = vec![Instruction::Jump(10)];
         let actual = eval(&inst, "abc");
         assert_eq!(actual, Err(EvalError::InvalidPC));
-    }
-
-    #[test]
-    fn test_eval_from_start() {
-        let ast = parse("abc").unwrap();
-        let inst = compile(&ast).unwrap();
-        assert!(eval_from_start(&inst, "abcxxx").unwrap());
-        assert!(!eval_from_start(&inst, "xabc").unwrap());
     }
 }

--- a/crates/regex-core/src/lib.rs
+++ b/crates/regex-core/src/lib.rs
@@ -102,8 +102,7 @@ impl Regex {
 
         let mut starts = Vec::with_capacity(byte_starts.len());
         let mut targets = byte_starts.into_iter().peekable();
-        let mut char_index = 0;
-        for (byte_index, _) in line.char_indices() {
+        for (char_index, (byte_index, _)) in line.char_indices().enumerate() {
             while let Some(target) = targets.peek() {
                 if *target == byte_index {
                     starts.push(char_index);
@@ -115,7 +114,6 @@ impl Regex {
             if targets.peek().is_none() {
                 break;
             }
-            char_index += 1;
         }
 
         starts


### PR DESCRIPTION
This pull request introduces a comprehensive regex pattern analysis to the `regex-core` crate, enabling extraction of deterministic "must-have" substrings, candidate literals (needles), and nullability from regex ASTs. The engine and evaluator APIs are updated to leverage these analyses, improving pre-filtering and match logic. Extensive tests are added to verify correctness and edge cases.

Regex pattern analysis and integration:

* Added the `AstAnalysis` struct and the `analyze_ast` function to `engine/ast.rs`, which extract must-have substrings, candidate literals, and nullability from regex ASTs. Limits are enforced to prefer longer literals and lexicographic order.
* Updated the `Regex` struct in `lib.rs` to store `must_literals`, `needles`, and `nullable`, and to initialize these via `compile_pattern_with_analysis`, replacing the previous `first_strings` logic. [[1]](diffhunk://#diff-93072f332b9d1246838b93c7635d3a3b51b8ef973241a753b92142615e17fe17L12-R19) [[2]](diffhunk://#diff-93072f332b9d1246838b93c7635d3a3b51b8ef973241a753b92142615e17fe17L27-R47)
* Added new engine functions: `compile_pattern_with_analysis` and `compile_pattern_with_must_literals`, which return compiled instructions along with analysis results.

Evaluator and matching improvements:

* Changed `eval_from_start` to `eval_from_starts` in `evaluator.rs`, allowing matching from multiple provided start indices, and updated engine and tests accordingly. [[1]](diffhunk://#diff-8054fa7c6b1a841e544cab8563fb9be4f51ec757948e165d0062281e87c0980eL254-R274) [[2]](diffhunk://#diff-4c321c203e7245d40e8b58ea21c1e7d788151a69a2ae902f6d6faca0d5a9a9d5L12-R16)
* Updated tests in `engine.rs` and `evaluator.rs` to verify new analysis features, must literals extraction, needle extraction, nullability, and multi-start matching. [[1]](diffhunk://#diff-4c321c203e7245d40e8b58ea21c1e7d788151a69a2ae902f6d6faca0d5a9a9d5L105-R146) [[2]](diffhunk://#diff-8054fa7c6b1a841e544cab8563fb9be4f51ec757948e165d0062281e87c0980eL284-R298) [[3]](diffhunk://#diff-8054fa7c6b1a841e544cab8563fb9be4f51ec757948e165d0062281e87c0980eL355-R374)

Documentation and review instructions:

* Added a Japanese-language code review checklist for Copilot reviewers in `.github/instructions/review/pr-review.instructions.md`, emphasizing code quality, naming, error handling, test coverage, and performance.